### PR TITLE
Change imports from "golang.org/x/tools/go/types" to "go/types" to fix compile error with Go 1.5.

### DIFF
--- a/cmd/aligncheck/aligncheck.go
+++ b/cmd/aligncheck/aligncheck.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/kisielk/gotool"
 	"golang.org/x/tools/go/loader"
-	"golang.org/x/tools/go/types"
+	"go/types"
 )
 
 var stdSizes = types.StdSizes{

--- a/cmd/structcheck/structcheck.go
+++ b/cmd/structcheck/structcheck.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/kisielk/gotool"
 	"golang.org/x/tools/go/loader"
-	"golang.org/x/tools/go/types"
+	"go/types"
 )
 
 var (

--- a/cmd/varcheck/varcheck.go
+++ b/cmd/varcheck/varcheck.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/kisielk/gotool"
 	"golang.org/x/tools/go/loader"
-	"golang.org/x/tools/go/types"
+	"go/types"
 )
 
 var (


### PR DESCRIPTION
Change imports from "golang.org/x/tools/go/types" to "go/types" to fix compile error with Go 1.5.

This addresses the issue https://github.com/opennota/check/issues/25