### PR TITLE
Fix false positive when const used in array length

### DIFF
--- a/cmd/varcheck/varcheck.go
+++ b/cmd/varcheck/varcheck.go
@@ -102,6 +102,9 @@ func (v *visitor) Visit(node ast.Node) ast.Visitor {
 		for _, val := range node.Values {
 			ast.Walk(v, val)
 		}
+		if node.Type != nil {
+			ast.Walk(v, node.Type)
+		}
 		return nil
 
 	case *ast.FuncDecl:


### PR DESCRIPTION
Similar to #38 but in this case it's a variable declaration, not a function argument.

This issue can be reproduced with this example:

```go
const (
	varchecktest = 10
)

func VarCheckTest() {
	var p [varchecktest]byte
	_ = p
}
```

Fixed by walking the array type.