### PR TITLE
Flags was renamed to BuildFlags

### DIFF
--- a/cmd/aligncheck/aligncheck.go
+++ b/cmd/aligncheck/aligncheck.go
@@ -49,7 +49,7 @@ func main() {
 	}
 	cfg := &packages.Config{
 		Mode:  packages.LoadSyntax,
-		Flags: flags,
+		BuildFlags: flags,
 		Error: func(error) {}, // don't print type check errors
 	}
 	pkgs, err := packages.Load(cfg, importPaths...)

--- a/cmd/structcheck/structcheck.go
+++ b/cmd/structcheck/structcheck.go
@@ -156,7 +156,7 @@ func main() {
 	cfg := &packages.Config{
 		Mode:  packages.LoadSyntax,
 		Tests: *loadTestFiles,
-		Flags: flags,
+		BuildFlags: flags,
 		Error: func(error) {}, // don't print type check errors
 	}
 	pkgs, err := packages.Load(cfg, importPaths...)

--- a/cmd/varcheck/varcheck.go
+++ b/cmd/varcheck/varcheck.go
@@ -141,7 +141,7 @@ func main() {
 	cfg := &packages.Config{
 		Mode:  packages.LoadSyntax,
 		Tests: true,
-		Flags: flags,
+		BuildFlags: flags,
 		Error: func(error) {}, // don't print type check errors
 	}
 	pkgs, err := packages.Load(cfg, importPaths...)


### PR DESCRIPTION
A breaking change was made yesterday:
https://github.com/golang/tools/commit/5fad05c81888302518e9dfb20b55b3e1790c7a11

This is for issue:
https://github.com/opennota/check/issues/45
