### PR TITLE
update with respect to changes to golang.org/x/tools/go/packages

### DIFF
--- a/cmd/aligncheck/aligncheck.go
+++ b/cmd/aligncheck/aligncheck.go
@@ -48,7 +48,7 @@ func main() {
 		flags = append(flags, fmt.Sprintf("-tags=%s", *buildTags))
 	}
 	cfg := &packages.Config{
-		Mode:  packages.LoadSyntax,
+		Mode:       packages.LoadSyntax,
 		BuildFlags: flags,
 	}
 	pkgs, err := packages.Load(cfg, importPaths...)

--- a/cmd/aligncheck/aligncheck.go
+++ b/cmd/aligncheck/aligncheck.go
@@ -50,7 +50,6 @@ func main() {
 	cfg := &packages.Config{
 		Mode:  packages.LoadSyntax,
 		BuildFlags: flags,
-		Error: func(error) {}, // don't print type check errors
 	}
 	pkgs, err := packages.Load(cfg, importPaths...)
 	if err != nil {

--- a/cmd/structcheck/structcheck.go
+++ b/cmd/structcheck/structcheck.go
@@ -157,7 +157,6 @@ func main() {
 		Mode:  packages.LoadSyntax,
 		Tests: *loadTestFiles,
 		BuildFlags: flags,
-		Error: func(error) {}, // don't print type check errors
 	}
 	pkgs, err := packages.Load(cfg, importPaths...)
 	if err != nil {

--- a/cmd/structcheck/structcheck.go
+++ b/cmd/structcheck/structcheck.go
@@ -154,8 +154,8 @@ func main() {
 		flags = append(flags, fmt.Sprintf("-tags=%s", *buildTags))
 	}
 	cfg := &packages.Config{
-		Mode:  packages.LoadSyntax,
-		Tests: *loadTestFiles,
+		Mode:       packages.LoadSyntax,
+		Tests:      *loadTestFiles,
 		BuildFlags: flags,
 	}
 	pkgs, err := packages.Load(cfg, importPaths...)

--- a/cmd/varcheck/varcheck.go
+++ b/cmd/varcheck/varcheck.go
@@ -139,8 +139,8 @@ func main() {
 		flags = append(flags, fmt.Sprintf("-tags=%s", *buildTags))
 	}
 	cfg := &packages.Config{
-		Mode:  packages.LoadSyntax,
-		Tests: true,
+		Mode:       packages.LoadSyntax,
+		Tests:      true,
 		BuildFlags: flags,
 	}
 	pkgs, err := packages.Load(cfg, importPaths...)

--- a/cmd/varcheck/varcheck.go
+++ b/cmd/varcheck/varcheck.go
@@ -142,7 +142,6 @@ func main() {
 		Mode:  packages.LoadSyntax,
 		Tests: true,
 		BuildFlags: flags,
-		Error: func(error) {}, // don't print type check errors
 	}
 	pkgs, err := packages.Load(cfg, importPaths...)
 	if err != nil {


### PR DESCRIPTION
The config.Error hook is gone, and the default behavior is now
the same as the behavior we wanted in these tools. Remove the code that
sets Error on the configs.